### PR TITLE
#168053399 add rejected page

### DIFF
--- a/ui/html/rejected.html
+++ b/ui/html/rejected.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>rejected page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../css/useractivity.css">
+</head>
+
+<body>
+    <div class="header">
+        <a href="#default" class="logo">FREE MENTORS</a>
+        <div class="header-right">
+            <a class="active" href="rejected.html">Rejected</a>
+            <a href="accepted.html">Accepted</a>
+            <a href="awaiting.html">Awaiting</a>
+            <a href="mentorslist.html">Browse Mentors</a>
+            <a href="../index.html">Logout</a>
+        </div>
+    </div>
+    <div class="wrapper">
+        <div class="card">
+            <div class="photo">
+                <img src="../images/user2.png" class="profile-img">
+            </div>
+            <div class="ps">
+                <p class="name">Nick Finck</p>
+                <p class="job-title">software engineer-robert bosch gmbh</p>
+                <p class="about">We’d like to thank you for requesting mentorship session to this mentor but at this
+                    time, we can’t move forward with your request, try other mentors
+                </p>
+            </div>
+        </div>
+</body>
+
+</html>


### PR DESCRIPTION
##What does this PR do?
user should be able to view  rejected sessions request page

##Description of task completed
Given a user
When a user click on rejected link user should be able to view list of rejected
sessions request
Then to provide history and meaningful information about declined sessions request easily

##What are the relevant pivotal tracker stories?
[#168053399](https://www.pivotaltracker.com/story/show/168053399)